### PR TITLE
fix "attempt to index global 'k' (a nil value)"

### DIFF
--- a/luci/themes/luci-theme-darkmatter/luasrc/view/themes/darkmatter/header.htm
+++ b/luci/themes/luci-theme-darkmatter/luasrc/view/themes/darkmatter/header.htm
@@ -210,7 +210,7 @@
 			 for i, r in ipairs(childs) do
 			 local nnode = cattree.nodes[r]
 			 local href  = controller .. "/" .. category .. "/" .. r ..
-			 (nnode.query and http.build_querystring(k.query) or "")
+			 (nnode.query and http.build_querystring(nnode.query) or "")
 			 local grandchildren = disp.node_childs(nnode)
 
 			 if #grandchildren > 0 then


### PR DESCRIPTION
this copy-paste error prevented luci-statistics from loading when alias for unauthenticated user is deployed